### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/wepay-core/src/main/java/me/hao0/wepay/model/enums/WepayField.java
+++ b/wepay-core/src/main/java/me/hao0/wepay/model/enums/WepayField.java
@@ -446,4 +446,8 @@ public final class WepayField {
      */
     public static final String REFUND_RECV_ACCOUNT = "refund_recv_accout";
 
+    private WepayField() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
+
 }

--- a/wepay-core/src/main/java/me/hao0/wepay/util/Maps.java
+++ b/wepay-core/src/main/java/me/hao0/wepay/util/Maps.java
@@ -18,6 +18,10 @@ import java.util.Map;
  */
 public final class Maps {
 
+    private Maps() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
+
     /**
      * 转换微信XML为Map(仅支持2级)
      * @param xml xml内容

--- a/wepay-core/src/main/java/me/hao0/wepay/util/RandomStrs.java
+++ b/wepay-core/src/main/java/me/hao0/wepay/util/RandomStrs.java
@@ -15,6 +15,10 @@ public final class RandomStrs {
 
     private static final Random random = new Random();
 
+    private RandomStrs() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
+
     /**
      * 生成随机字符串
      * @param length 长度


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat